### PR TITLE
ログイン、パスワードを変更するのバリデーションを追加

### DIFF
--- a/components/auth/form/FormEmail.vue
+++ b/components/auth/form/FormEmail.vue
@@ -3,6 +3,7 @@
     v-model="valueModel"
     :label="$t('email')"
     :error-messages="errorMessage"
+    @blur="$v.v.$touch()"
     outlined
     clearable
   />

--- a/components/auth/form/FormEmail.vue
+++ b/components/auth/form/FormEmail.vue
@@ -1,0 +1,47 @@
+<template>
+  <v-text-field
+    v-model="valueModel"
+    :label="$t('email')"
+    :error-messages="errorMessage"
+    outlined
+    clearable
+  />
+</template>
+
+<script>
+import { email, maxLength, required } from 'vuelidate/lib/validators'
+import { form } from '@/mixins/form'
+
+export default {
+  mixins: [form],
+
+  validations: {
+    v: {
+      email,
+      maxLength: maxLength(255),
+      required
+    }
+  },
+
+  computed: {
+    /**
+     * エラーメッセージ
+     *
+     * @return {String[]} エラーメッセージ
+     */
+    errorMessage() {
+      const validate = this.$v.v
+      // ユーザーが一回以上touchしたか
+      if (!this.dirty || !validate.$dirty) {
+        return this.errorServerMessage
+      }
+
+      const errors = []
+      !validate.required && errors.push('メールアドレスは必須です')
+      !validate.email && errors.push('正しいメールアドレスを入力してください')
+      !validate.maxLength && errors.push('255文字以内で入力してください')
+      return errors
+    }
+  }
+}
+</script>

--- a/components/auth/form/FormEmailOrName.vue
+++ b/components/auth/form/FormEmailOrName.vue
@@ -1,18 +1,16 @@
 <template>
   <v-text-field
     v-model="valueModel"
-    :append-icon="hidden ? 'mdi-eye-off' : 'mdi-eye'"
-    :label="$t('password')"
+    :label="$t('email')"
     :error-messages="errorMessage"
-    :type="hidden ? 'password' : 'text'"
-    @click:append="hidden = !hidden"
     @blur="$v.v.$touch()"
     outlined
+    clearable
   />
 </template>
 
 <script>
-import { minLength, required } from 'vuelidate/lib/validators'
+import { maxLength, required } from 'vuelidate/lib/validators'
 import { form } from '@/mixins/form'
 
 export default {
@@ -20,14 +18,8 @@ export default {
 
   validations: {
     v: {
-      minLength: minLength(8),
+      maxLength: maxLength(255),
       required
-    }
-  },
-
-  data() {
-    return {
-      hidden: true
     }
   },
 
@@ -45,8 +37,8 @@ export default {
       }
 
       const errors = []
-      !validate.required && errors.push('パスワードは必須です')
-      !validate.minLength && errors.push('8文字以上で入力してください')
+      !validate.required && errors.push('ユーザー名かメールアドレスは必須です')
+      !validate.maxLength && errors.push('255文字以内で入力してください')
       return errors
     }
   }

--- a/components/auth/form/FormPassword.vue
+++ b/components/auth/form/FormPassword.vue
@@ -1,0 +1,69 @@
+<template>
+  <div>
+    <v-text-field
+      v-model="valueModel"
+      :label="$t('password')"
+      :error-messages="errorMessage"
+      outlined
+      clearable
+    />
+
+    <v-text-field
+      v-model="valueConfirmationModel"
+      :label="$t('confirm_password')"
+      :error-messages="errorMessageConfirmation"
+      outlined
+      clearable
+    />
+  </div>
+</template>
+
+<script>
+import { minLength, sameAs, required } from 'vuelidate/lib/validators'
+import { formConfirmation } from '@/mixins/formConfirmation'
+
+export default {
+  mixins: [formConfirmation],
+
+  validations: {
+    v: {
+      minLength: minLength(8),
+      required
+    },
+
+    vc: {
+      sameAs: sameAs('value')
+    }
+  },
+
+  computed: {
+    /**
+     * エラーメッセージ
+     *
+     * @return {String[]} エラーメッセージ
+     */
+    errorMessage() {
+      const validate = this.$v.v
+      // ユーザーが一回以上touchしたか
+      if (!this.dirty || !validate.$dirty) {
+        return this.errorServerMessage
+      }
+
+      const errors = []
+      !validate.required && errors.push('パスワードは必須です')
+      !validate.minLength && errors.push('8文字以上で入力してください')
+      return errors
+    },
+
+    errorMessageConfirmation() {
+      const validateConfiramtion = this.$v.vc
+      if (!this.dirty || !validateConfiramtion.$dirty) {
+        return this.errorServerMessage
+      }
+      const errors = []
+      !validateConfiramtion.sameAs && errors.push('パスワードが一致しません。')
+      return errors
+    }
+  }
+}
+</script>

--- a/components/auth/form/FormPassword.vue
+++ b/components/auth/form/FormPassword.vue
@@ -4,6 +4,7 @@
       v-model="valueModel"
       :label="$t('password')"
       :error-messages="errorMessage"
+      @blur="$v.v.$touch()"
       outlined
       clearable
     />
@@ -12,6 +13,7 @@
       v-model="valueConfirmationModel"
       :label="$t('confirm_password')"
       :error-messages="errorMessageConfirmation"
+      @blur="$v.vc.$touch()"
       outlined
       clearable
     />

--- a/components/auth/form/FormPasswordWithConfirmation.vue
+++ b/components/auth/form/FormPasswordWithConfirmation.vue
@@ -1,0 +1,82 @@
+<template>
+  <div>
+    <v-text-field
+      v-model="valueModel"
+      :append-icon="hidden ? 'mdi-eye-off' : 'mdi-eye'"
+      :error-messages="errorMessage"
+      :label="$t('password')"
+      :type="hidden ? 'password' : 'text'"
+      @click:append="hidden = !hidden"
+      @blur="$v.v.$touch()"
+      outlined
+    />
+
+    <v-text-field
+      v-model="valueConfirmationModel"
+      :append-icon="hidden2 ? 'mdi-eye-off' : 'mdi-eye'"
+      :error-messages="errorMessageConfirmation"
+      :label="$t('confirm_password')"
+      :type="hidden2 ? 'password' : 'text'"
+      @click:append="hidden2 = !hidden2"
+      @blur="$v.vc.$touch()"
+      outlined
+    />
+  </div>
+</template>
+
+<script>
+import { minLength, sameAs, required } from 'vuelidate/lib/validators'
+import { formConfirmation } from '@/mixins/formConfirmation'
+
+export default {
+  mixins: [formConfirmation],
+
+  validations: {
+    v: {
+      minLength: minLength(8),
+      required
+    },
+
+    vc: {
+      sameAs: sameAs('value')
+    }
+  },
+
+  data() {
+    return {
+      hidden: true,
+      hidden2: true
+    }
+  },
+
+  computed: {
+    /**
+     * エラーメッセージ
+     *
+     * @return {String[]} エラーメッセージ
+     */
+    errorMessage() {
+      const validate = this.$v.v
+      // ユーザーが一回以上touchしたか
+      if (!this.dirty || !validate.$dirty) {
+        return this.errorServerMessage
+      }
+
+      const errors = []
+      !validate.required && errors.push('パスワードは必須です')
+      !validate.minLength && errors.push('8文字以上で入力してください')
+      return errors
+    },
+
+    errorMessageConfirmation() {
+      const validateConfiramtion = this.$v.vc
+      if (!this.dirty || !validateConfiramtion.$dirty) {
+        return this.errorServerMessage
+      }
+      const errors = []
+      !validateConfiramtion.sameAs && errors.push('パスワードが一致しません。')
+      return errors
+    }
+  }
+}
+</script>

--- a/mixins/form.js
+++ b/mixins/form.js
@@ -15,6 +15,11 @@ export const form = {
       default: null
     },
 
+    lazyValidation: {
+      type: Boolean,
+      default: false
+    },
+
     objKey: {
       type: String,
       required: true
@@ -56,7 +61,10 @@ export const form = {
       },
       set(newVal) {
         this.v = newVal
-        this.$v.v.$touch()
+
+        if (!this.lazyValidation) {
+          this.$v.v.$touch()
+        }
 
         if (!this.dirty) {
           this.$emit('dirty')

--- a/mixins/formConfirmation.js
+++ b/mixins/formConfirmation.js
@@ -1,4 +1,4 @@
-export const form = {
+export const formConfirmation = {
   props: {
     /**
      * v-model
@@ -30,6 +30,11 @@ export const form = {
     errors: {
       type: Object,
       default: null
+    },
+
+    lazyValidation: {
+      type: Boolean,
+      default: false
     },
 
     objKey: {
@@ -74,7 +79,10 @@ export const form = {
       },
       set(newVal) {
         this.v = newVal
-        this.$v.v.$touch()
+
+        if (!this.lazyValidation) {
+          this.$v.v.$touch()
+        }
 
         if (!this.dirty) {
           this.$emit('dirty')
@@ -90,7 +98,10 @@ export const form = {
       },
       set(newVal) {
         this.vc = newVal
-        this.$v.vc.$touch()
+
+        if (!this.lazyValidation) {
+          this.$v.vc.$touch()
+        }
 
         if (!this.dirty) {
           this.$emit('dirty')

--- a/mixins/formConfirmation.js
+++ b/mixins/formConfirmation.js
@@ -1,0 +1,103 @@
+export const form = {
+  props: {
+    /**
+     * v-model
+     */
+    value: { type: String, default: '' },
+
+    /**
+     * 確認したいフィールドの値
+     *
+     * ex. password_confirmation
+     */
+    confirmationField: {
+      type: String,
+      required: false,
+      default: ''
+    },
+
+    /**
+     * ユーザがフォームの内容を変更したか
+     */
+    dirty: {
+      type: Boolean,
+      required: true
+    },
+
+    /**
+     * APIで発生したエラー
+     */
+    errors: {
+      type: Object,
+      default: null
+    },
+
+    objKey: {
+      type: String,
+      required: true
+    }
+  },
+
+  data() {
+    return {
+      v: this.value,
+      vc: this.confirmationField
+    }
+  },
+
+  computed: {
+    /**
+     * サーバーでエラーが発生したかどうか
+     *
+     * @return {Boolean}
+     */
+    isErrorServer() {
+      const err = this.errors.errors
+      return err && this.objKey in err && `${this.objKey}_confirmation` in err
+    },
+
+    /**
+     * サーバーで発生したエラー
+     *
+     * @return {String[]}
+     */
+    errorServerMessage() {
+      if (this.isErrorServer) {
+        return this.errors.errors[this.objKey]
+      }
+      return []
+    },
+
+    valueModel: {
+      get() {
+        return this.$v.v.$model
+      },
+      set(newVal) {
+        this.v = newVal
+        this.$v.v.$touch()
+
+        if (!this.dirty) {
+          this.$emit('dirty')
+        }
+
+        return this.$emit('input', newVal)
+      }
+    },
+
+    valueConfirmationModel: {
+      get() {
+        return this.$v.vc.$model
+      },
+      set(newVal) {
+        this.vc = newVal
+        this.$v.vc.$touch()
+
+        if (!this.dirty) {
+          this.$emit('dirty')
+        }
+
+        return this.$emit('confirmation', newVal)
+      }
+    }
+  }
+}

--- a/pages/auth/login.vue
+++ b/pages/auth/login.vue
@@ -2,22 +2,23 @@
   <auth-wrapper>
     <auth-form>
       <v-form @submit.prevent="login" @keydown="form.onKeydown($event)">
-        <v-text-field
+        <!-- Email -->
+        <form-email-or-name
           v-model="form.email"
-          :rules="rules.email"
-          :counter="255"
-          :label="$t('username_or_email')"
-          required
+          :dirty="formDirty"
+          :errors="form.errors"
+          :lazy-validation="true"
+          @dirty="dirty"
+          obj-key="email"
         />
 
-        <v-text-field
+        <form-password
           v-model="form.password"
-          :append-icon="field.password ? 'mdi-eye' : 'mdi-eye-off'"
-          :rules="rules.password"
-          :type="field.password ? 'text' : 'password'"
-          :label="$t('password')"
-          @click:append="field.password = !field.password"
-          required
+          :dirty="formDirty"
+          :errors="form.errors"
+          :lazy-validation="true"
+          @dirty="dirty"
+          obj-key="password"
         />
 
         <div class="d-flex justify-space-between">
@@ -42,9 +43,6 @@
           >
             {{ $t('login') }}
           </v-btn>
-
-          <!-- GitHub Login Button -->
-          <login-with-github />
         </div>
       </v-form>
     </auth-form>
@@ -55,6 +53,8 @@
 import Form from 'vform'
 import AuthForm from '~/components/auth/AuthForm'
 import AuthWrapper from '~/components/auth/AuthWrapper'
+import FormEmailOrName from '@/components/auth/form/FormEmailOrName'
+import FormPassword from '@/components/auth/form/FormPassword'
 
 export default {
   head() {
@@ -63,7 +63,9 @@ export default {
 
   components: {
     AuthForm,
-    AuthWrapper
+    AuthWrapper,
+    FormEmailOrName,
+    FormPassword
   },
 
   layout: 'auth',
@@ -73,14 +75,8 @@ export default {
       email: '',
       password: ''
     }),
+    formDirty: false,
     remember: false,
-    rules: {
-      email: [(v) => !!v || 'Name is required'],
-      password: [
-        (v) => !!v || 'Password is required',
-        (v) => v.length >= 7 || 'Password must be more than 7 characters'
-      ]
-    },
     field: {
       password: false
     }
@@ -89,6 +85,10 @@ export default {
   middleware: 'guest',
 
   methods: {
+    dirty() {
+      this.formDirty = true
+    },
+
     async login() {
       let data
 

--- a/pages/auth/password/email.vue
+++ b/pages/auth/password/email.vue
@@ -5,13 +5,13 @@
         <alert-success :form="form" :message="status" />
 
         <!-- Email -->
-        <v-text-field
+        <form-email
           v-model="form.email"
-          :class="{ 'is-invalid': form.errors.has('email') }"
-          :label="$t('email')"
-          required
+          :dirty="formDirty"
+          :errors="form.errors"
+          @dirty="dirty"
+          obj-key="email"
         />
-        <has-error :form="form" field="email" />
 
         <div class="text-center login-btn-wraaper">
           <!-- Submit Button -->
@@ -33,6 +33,7 @@
 import Form from 'vform'
 import AuthForm from '~/components/auth/AuthForm'
 import AuthWrapper from '~/components/auth/AuthWrapper'
+import FormEmail from '@/components/auth/form/FormEmail'
 
 export default {
   head() {
@@ -41,19 +42,25 @@ export default {
 
   components: {
     AuthForm,
-    AuthWrapper
+    AuthWrapper,
+    FormEmail
   },
 
   layout: 'auth',
 
   data: () => ({
     status: '',
+    formDirty: false,
     form: new Form({
       email: ''
     })
   }),
 
   methods: {
+    dirty() {
+      this.formDirty = true
+    },
+
     async send() {
       try {
         const { data } = await this.form.post('/password/email')

--- a/pages/auth/password/email.vue
+++ b/pages/auth/password/email.vue
@@ -9,6 +9,7 @@
           v-model="form.email"
           :dirty="formDirty"
           :errors="form.errors"
+          :lazy-validation="true"
           @dirty="dirty"
           obj-key="email"
         />

--- a/pages/auth/password/reset.vue
+++ b/pages/auth/password/reset.vue
@@ -9,6 +9,7 @@
           v-model="form.email"
           :dirty="formDirty"
           :errors="form.errors"
+          :lazy-validation="true"
           @dirty="dirty"
           obj-key="email"
         />
@@ -19,6 +20,7 @@
           :confirmationField="form.password_confirmation"
           :dirty="formDirty"
           :errors="form.errors"
+          :lazy-validation="true"
           @confirmation="updatePasswordConfirmation"
           @dirty="dirty"
           obj-key="password"

--- a/pages/auth/password/reset.vue
+++ b/pages/auth/password/reset.vue
@@ -1,88 +1,69 @@
 <template>
-  <div class="row">
-    <div class="col-lg-8 m-auto">
-      <card :title="$t('reset_password')">
-        <form @submit.prevent="reset" @keydown="form.onKeydown($event)">
-          <alert-success :form="form" :message="status" />
+  <auth-wrapper>
+    <auth-form>
+      <v-form @submit.prevent="reset" @keydown="form.onKeydown($event)">
+        <alert-success :form="form" :message="status" />
 
-          <!-- Email -->
-          <div class="form-group row">
-            <label class="col-md-3 col-form-label text-md-right">{{
-              $t('email')
-            }}</label>
-            <div class="col-md-7">
-              <input
-                v-model="form.email"
-                :class="{ 'is-invalid': form.errors.has('email') }"
-                type="email"
-                name="email"
-                class="form-control"
-                readonly
-              />
-              <has-error :form="form" field="email" />
-            </div>
-          </div>
+        <!-- Email -->
+        <form-email
+          v-model="form.email"
+          :dirty="formDirty"
+          :errors="form.errors"
+          @dirty="dirty"
+          obj-key="email"
+        />
 
-          <!-- Password -->
-          <div class="form-group row">
-            <label class="col-md-3 col-form-label text-md-right">{{
-              $t('password')
-            }}</label>
-            <div class="col-md-7">
-              <input
-                v-model="form.password"
-                :class="{ 'is-invalid': form.errors.has('password') }"
-                type="password"
-                name="password"
-                class="form-control"
-              />
-              <has-error :form="form" field="password" />
-            </div>
-          </div>
+        <!-- Password -->
+        <form-password
+          v-model="form.password"
+          :confirmationField="form.password_confirmation"
+          :dirty="formDirty"
+          :errors="form.errors"
+          @confirmation="updatePasswordConfirmation"
+          @dirty="dirty"
+          obj-key="password"
+        />
 
-          <!-- Password Confirmation -->
-          <div class="form-group row">
-            <label class="col-md-3 col-form-label text-md-right">{{
-              $t('confirm_password')
-            }}</label>
-            <div class="col-md-7">
-              <input
-                v-model="form.password_confirmation"
-                :class="{
-                  'is-invalid': form.errors.has('password_confirmation')
-                }"
-                type="password"
-                name="password_confirmation"
-                class="form-control"
-              />
-              <has-error :form="form" field="password_confirmation" />
-            </div>
-          </div>
-
+        <div class="text-center login-btn-wraaper">
           <!-- Submit Button -->
-          <div class="form-group row">
-            <div class="col-md-9 ml-md-auto">
-              <v-button :loading="form.busy">
-                {{ $t('reset_password') }}
-              </v-button>
-            </div>
-          </div>
-        </form>
-      </card>
-    </div>
-  </div>
+          <v-btn
+            :disabled="form.busy"
+            color="grey lighten-1"
+            large
+            type="submit"
+          >
+            {{ $t('reset_password') }}
+          </v-btn>
+        </div>
+      </v-form>
+    </auth-form>
+  </auth-wrapper>
 </template>
 
 <script>
 import Form from 'vform'
+import AuthForm from '~/components/auth/AuthForm'
+import AuthWrapper from '~/components/auth/AuthWrapper'
+import FormEmail from '@/components/auth/form/FormEmail'
+import FormPassword from '@/components/auth/form/FormPassword'
 
 export default {
   head() {
     return { title: this.$t('reset_password') }
   },
 
+  components: {
+    AuthForm,
+    AuthWrapper,
+    FormEmail,
+    FormPassword
+  },
+
+  layout: 'auth',
+
   data: () => ({
     status: '',
+    formDirty: false,
     form: new Form({
       token: '',
       email: '',
@@ -97,6 +78,14 @@ export default {
   },
 
   methods: {
+    dirty() {
+      this.formDirty = true
+    },
+
+    updatePasswordConfirmation(value) {
+      this.form.password_confirmation = value
+    },
+
     async reset() {
       const { data } = await this.form.post('/password/reset')
 

--- a/pages/auth/password/reset.vue
+++ b/pages/auth/password/reset.vue
@@ -2,8 +2,6 @@
   <auth-wrapper>
     <auth-form>
       <v-form @submit.prevent="reset" @keydown="form.onKeydown($event)">
-        <alert-success :form="form" :message="status" />
-
         <!-- Email -->
         <form-email
           v-model="form.email"
@@ -94,6 +92,8 @@ export default {
       this.status = data.status
 
       this.form.reset()
+
+      this.$router.push({ name: 'password.reset.success' })
     }
   }
 }

--- a/pages/auth/password/reset.vue
+++ b/pages/auth/password/reset.vue
@@ -13,7 +13,7 @@
         />
 
         <!-- Password -->
-        <form-password
+        <form-password-with-confirmation
           v-model="form.password"
           :confirmationField="form.password_confirmation"
           :dirty="formDirty"
@@ -45,7 +45,7 @@ import Form from 'vform'
 import AuthForm from '~/components/auth/AuthForm'
 import AuthWrapper from '~/components/auth/AuthWrapper'
 import FormEmail from '@/components/auth/form/FormEmail'
-import FormPassword from '@/components/auth/form/FormPassword'
+import FormPasswordWithConfirmation from '@/components/auth/form/FormPasswordWithConfirmation'
 
 export default {
   head() {
@@ -56,7 +56,7 @@ export default {
     AuthForm,
     AuthWrapper,
     FormEmail,
-    FormPassword
+    FormPasswordWithConfirmation
   },
 
   layout: 'auth',

--- a/pages/auth/password/success.vue
+++ b/pages/auth/password/success.vue
@@ -1,0 +1,23 @@
+<template>
+  <auth-wrapper>
+    <auth-form>
+      <p>パスワードの変更をしました</p>
+
+      <nuxt-link :to="{ name: 'login' }">ログインへ</nuxt-link>
+    </auth-form>
+  </auth-wrapper>
+</template>
+
+<script>
+import AuthForm from '~/components/auth/AuthForm'
+import AuthWrapper from '~/components/auth/AuthWrapper'
+
+export default {
+  components: {
+    AuthForm,
+    AuthWrapper
+  },
+
+  layout: 'auth'
+}
+</script>

--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,7 @@ $ npm run dev
 
 - 新規登録(/register)
 
-- パスワード再発行(/未定義)
+- パスワード再発行(/password/reset)
 
 ### 会員ページ
 

--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,11 @@ $ npm run dev
 
 - 新規登録(/register)
 
-- パスワード再発行(/password/reset)
+- パスワード再発行申請画面(/password/reset)
+
+- パスワードを変更(/password/reset/:token)
+
+- パスワードの変更完了画面(/password/reset/success)
 
 ### 会員ページ
 

--- a/router.js
+++ b/router.js
@@ -93,6 +93,11 @@ const routes = [
     component: page('auth/password/email.vue')
   },
   {
+    path: '/password/reset/success',
+    name: 'password.reset.success',
+    component: page('auth/password/success.vue')
+  },
+  {
     path: '/password/reset/:token',
     name: 'password.reset',
     component: page('auth/password/reset.vue')


### PR DESCRIPTION
# やったこと
- ログイン画面(/login)のバリデーションを追加
- パスワードを変更する(/password/reset)のバリデーションを追加
- パスワードを変更完了画面の追加(/password/reset/success)を追加
- _confirmation付きフォーム用のmixinを追加(mixins/formConfirmation.js)