### PR TITLE
#89 パース画像の廃止とそこそこ修正

### DIFF
--- a/components/molecues/dropdown/BaseDropdown.vue
+++ b/components/molecues/dropdown/BaseDropdown.vue
@@ -1,0 +1,66 @@
+<template>
+  <v-menu :open-on-hover="openOnHover" offset-y>
+    <template v-slot:activator="{ on }">
+      <v-btn v-on="on" :color="color" :dark="dark" large>
+        {{ title }}
+        <v-icon v-text="icon" />
+      </v-btn>
+    </template>
+
+    <v-list>
+      <v-list-item
+        v-for="(value, key) in items"
+        :key="key"
+        @click.prevent="selectItem(key)"
+      >
+        <v-list-item-title v-text="value" />
+      </v-list-item>
+    </v-list>
+  </v-menu>
+</template>
+
+<script>
+export default {
+  props: {
+    color: {
+      type: String,
+      required: false,
+      default: 'grey lighten-2'
+    },
+
+    dark: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+
+    icon: {
+      type: String,
+      required: false,
+      default: 'mdi-chevron-down'
+    },
+
+    items: {
+      type: [Array, Object],
+      required: true
+    },
+
+    openOnHover: {
+      type: Boolean,
+      required: false,
+      default: true
+    },
+
+    title: {
+      type: String,
+      required: true
+    }
+  },
+
+  methods: {
+    selectItem(newVal) {
+      return this.$emit('select-dropdown', newVal)
+    }
+  }
+}
+</script>

--- a/components/molecues/dropdown/BaseDropdown.vue
+++ b/components/molecues/dropdown/BaseDropdown.vue
@@ -11,7 +11,7 @@
       <v-list-item
         v-for="(value, key) in items"
         :key="key"
-        @click.prevent="selectItem(key)"
+        @click.prevent="clickItem(key)"
       >
         <v-list-item-title v-text="value" />
       </v-list-item>
@@ -58,8 +58,8 @@ export default {
   },
 
   methods: {
-    selectItem(newVal) {
-      return this.$emit('select-dropdown', newVal)
+    clickItem(newVal) {
+      return this.$emit('click', newVal)
     }
   }
 }

--- a/components/molecues/form/BaseFileInput.vue
+++ b/components/molecues/form/BaseFileInput.vue
@@ -47,6 +47,9 @@ export default {
       default: ''
     },
 
+    /**
+     * @see { @link https://github.com/vuetifyjs/vuetify/blob/master/packages/vuetify/src/components/VFileInput/VFileInput.ts | Vuetify }
+     */
     value: {
       default: undefined,
       validator: (val) => {

--- a/components/molecues/form/BaseFileInput.vue
+++ b/components/molecues/form/BaseFileInput.vue
@@ -1,0 +1,77 @@
+<template>
+  <div>
+    <v-file-input
+      v-model="valueModel"
+      @change="onChange"
+      :accept="accept"
+      :class="{ 'v-file-input-icon-none': noIcon }"
+      :filled="filled"
+      :height="height"
+      :label="label"
+    />
+  </div>
+</template>
+
+<script>
+import { convertToArray } from '@/utils/array'
+
+export default {
+  props: {
+    accept: {
+      type: String,
+      required: false,
+      default: ''
+    },
+
+    filled: {
+      type: Boolean,
+      required: false,
+      default: true
+    },
+
+    height: {
+      type: [Number, String],
+      required: false,
+      default: undefined
+    },
+
+    noIcon: {
+      type: Boolean,
+      required: false,
+      default: true
+    },
+
+    label: {
+      type: String,
+      required: false,
+      default: ''
+    },
+
+    value: {
+      default: undefined,
+      validator: (val) => {
+        return convertToArray(val).every(
+          (v) => v != null && typeof v === 'object'
+        )
+      }
+    }
+  },
+
+  computed: {
+    valueModel: {
+      get() {
+        return this.value
+      },
+      set(newVal) {
+        return this.$emit('input', newVal)
+      }
+    }
+  },
+
+  methods: {
+    onChange(e) {
+      return this.$emit('change', e)
+    }
+  }
+}
+</script>

--- a/components/molecues/form/ImageFileInput.vue
+++ b/components/molecues/form/ImageFileInput.vue
@@ -85,6 +85,7 @@ export default {
   methods: {
     onChange(e) {
       // e は FILE Objectであることに注意
+      this.$emit('change', e)
       try {
         this.newPreview = URL.createObjectURL(e)
       } catch (err) {

--- a/components/molecues/form/ImageFileInput.vue
+++ b/components/molecues/form/ImageFileInput.vue
@@ -1,0 +1,96 @@
+<template>
+  <eye-catch-image-display :height="height" :src="getPreview">
+    <base-file-input
+      v-model="valueModel"
+      @change="onChange"
+      :accept="accept"
+      :height="height"
+      :label="label"
+      no-icon
+    />
+  </eye-catch-image-display>
+</template>
+
+<script>
+import BaseFileInput from '@/components/molecues/form/BaseFileInput'
+import EyeCatchImageDisplay from '@/components/molecues/form/EyeCatchImageDisplay'
+import { convertToArray } from '@/utils/array'
+
+export default {
+  components: {
+    BaseFileInput,
+    EyeCatchImageDisplay
+  },
+
+  props: {
+    accept: {
+      type: String,
+      required: false,
+      default: 'image/*'
+    },
+
+    height: {
+      type: [Number, String],
+      required: false,
+      default: undefined
+    },
+
+    label: {
+      type: String,
+      required: false,
+      default: ''
+    },
+
+    preview: {
+      type: String,
+      required: false,
+      default: null
+    },
+
+    /**
+     * @see { @link https://github.com/vuetifyjs/vuetify/blob/master/packages/vuetify/src/components/VFileInput/VFileInput.ts | Vuetify }
+     */
+    value: {
+      default: undefined,
+      validator: (val) => {
+        return convertToArray(val).every(
+          (v) => v != null && typeof v === 'object'
+        )
+      }
+    }
+  },
+
+  data() {
+    return {
+      newPreview: null
+    }
+  },
+
+  computed: {
+    getPreview() {
+      return this.newPreview || this.preview
+    },
+
+    valueModel: {
+      get() {
+        return this.value
+      },
+
+      set(newVal) {
+        return this.$emit('input', newVal)
+      }
+    }
+  },
+
+  methods: {
+    onChange(e) {
+      // e は FILE Objectであることに注意
+      try {
+        this.newPreview = URL.createObjectURL(e)
+      } catch (err) {
+        this.newPreview = null
+      }
+    }
+  }
+}
+</script>

--- a/components/organisms/dropdown/LocaleDropdown.vue
+++ b/components/organisms/dropdown/LocaleDropdown.vue
@@ -1,28 +1,25 @@
 <template>
-  <v-menu offset-y open-on-hover>
-    <template v-slot:activator="{ on }">
-      <v-btn v-on="on" :color="color" :dark="dark" large>
-        {{ locales[locale] }}
-        <v-icon>mdi-chevron-down</v-icon>
-      </v-btn>
-    </template>
-    <v-list>
-      <v-list-item
-        v-for="(value, key) in locales"
-        :key="key"
-        @click.prevent="setLocale(key)"
-      >
-        <v-list-item-title>{{ value }}</v-list-item-title>
-      </v-list-item>
-    </v-list>
-  </v-menu>
+  <div>
+    <base-dropdown
+      :color="color"
+      :dark="dark"
+      :items="locales"
+      :title="locales[locale]"
+      @select-dropdown="setLocale"
+    />
+  </div>
 </template>
 
 <script>
 import { mapGetters } from 'vuex'
+import BaseDropdown from '@/components/molecues/dropdown/BaseDropdown'
 import { loadMessages } from '~/plugins/i18n'
 
 export default {
+  components: {
+    BaseDropdown
+  },
+
   props: {
     color: {
       type: String,

--- a/components/organisms/dropdown/LocaleDropdown.vue
+++ b/components/organisms/dropdown/LocaleDropdown.vue
@@ -5,7 +5,7 @@
       :dark="dark"
       :items="locales"
       :title="locales[locale]"
-      @select-dropdown="setLocale"
+      @click="setLocale"
     />
   </div>
 </template>

--- a/components/organisms/form/AuthNavbar.vue
+++ b/components/organisms/form/AuthNavbar.vue
@@ -11,7 +11,7 @@
 </template>
 
 <script>
-import LocaleDropdown from '~/components/organisms/LocaleDropdown'
+import LocaleDropdown from '@/components/organisms/dropdown/LocaleDropdown'
 import OtherPageLink from '~/components/molecues/auth/OtherPageLink'
 
 export default {

--- a/components/organisms/navbar/UserNavbar.vue
+++ b/components/organisms/navbar/UserNavbar.vue
@@ -89,7 +89,7 @@
 
 <script>
 import { mapGetters } from 'vuex'
-import LocaleDropdown from '~/components/organisms/LocaleDropdown'
+import LocaleDropdown from '@/components/organisms/dropdown/LocaleDropdown'
 
 export default {
   components: {

--- a/components/templates/pages/UserStoragePage.vue
+++ b/components/templates/pages/UserStoragePage.vue
@@ -1,11 +1,7 @@
 <template>
   <div>
-    <div style="width: 100%; height: 200px; background-color:green">
-      モデルの表示
-    </div>
-
     <v-row>
-      <v-col cols="6">
+      <v-col cols="12">
         <v-img :src="getEyecatchSrc(storage.eyecatch_image)" />
 
         <v-row>
@@ -21,7 +17,7 @@
         </v-row>
       </v-col>
 
-      <v-col cols="6">
+      <v-col cols="12">
         <tab-box :content="storage.long_comment" title="Comment" />
       </v-col>
     </v-row>

--- a/pages/pages/_user.vue
+++ b/pages/pages/_user.vue
@@ -29,7 +29,7 @@
           </v-tab-item>
 
           <v-tab-item>
-            <v-card flat>
+            <v-card flat style="min-height: 640px">
               <tab-box
                 :content="data.user_profile.web_address"
                 title="My Site"

--- a/pages/users/storages/create.vue
+++ b/pages/users/storages/create.vue
@@ -81,14 +81,14 @@
               </v-col>
 
               <v-col cols="5">
-                <h3>Stl obj fbxファイル</h3>
+                <h3>Stl objファイル</h3>
 
                 <div class="pos-relative v-file-input-icon-none">
                   <!-- storage -->
                   <v-file-input
                     v-model="form.storage"
                     :label="$t('storage')"
-                    accept=".obj, .stl, .fbx"
+                    accept=".obj, .stl"
                     filled
                     height="200px"
                   />

--- a/pages/users/storages/edit.vue
+++ b/pages/users/storages/edit.vue
@@ -66,20 +66,15 @@
               <v-col cols="7">
                 <h3>{{ $t('eyecatch_image') }}</h3>
 
-                <eye-catch-image-display
-                  :src="eyecatch_image_display_src"
+                <!-- eyecatch_image -->
+                <image-file-input
+                  v-model="form.eyecatch_image"
+                  :label="$t('eyecatch_image')"
+                  :preview="eyecatch_image_display_src"
+                  accept="image/*"
+                  filled
                   height="200px"
-                >
-                  <!-- eyecatch_image -->
-                  <v-file-input
-                    v-model="form.eyecatch_image"
-                    :label="$t('eyecatch_image')"
-                    @change="eyecatchImageFileChange"
-                    accept="image/*"
-                    filled
-                    height="200px"
-                  />
-                </eye-catch-image-display>
+                />
               </v-col>
 
               <v-col cols="5">
@@ -112,7 +107,7 @@
               <v-row>
                 <v-col cols="2">
                   <base-file-input
-                    v-model="form.storage_sub_image[newNumber]"
+                    v-model="form.storage_sub_images[newNumber]"
                     @change="subImageFileChange"
                     accept="image/*"
                     filled
@@ -128,7 +123,7 @@
                   cols="2"
                 >
                   <base-file-input
-                    v-model="form.storage_sub_image[subImageNum - 1]"
+                    v-model="form.storage_sub_images[subImageNum - 1]"
                     @change="subImageFileChange"
                     accept="image/*"
                     filled
@@ -188,11 +183,11 @@ import axios from 'axios'
 import Form from 'vform'
 import { objectToFormData } from 'object-to-formdata'
 import BaseFileInput from '@/components/molecues/form/BaseFileInput'
-import EyeCatchImageDisplay from '@/components/molecues/form/EyeCatchImageDisplay'
 import FormTitle from '@/components/molecues/form/FormTitle'
 import FormWebAddress from '@/components/molecues/form/FormWebAddress'
 import FormDescription from '@/components/molecues/form/FormDescription'
 import FormLongComment from '@/components/molecues/form/FormLongComment'
+import ImageFileInput from '@/components/molecues/form/ImageFileInput'
 import UserTitle from '~/components/molecues/pages/UserTitle'
 
 // ストレージIDの不一致時にエラーを投げる
@@ -204,11 +199,11 @@ export default {
   middleware: 'auth',
   components: {
     BaseFileInput,
-    EyeCatchImageDisplay,
     FormTitle,
     FormWebAddress,
     FormDescription,
     FormLongComment,
+    ImageFileInput,
     UserTitle
   },
 
@@ -225,14 +220,15 @@ export default {
         eyecatch_image_id: '' /* UUID Never Change!! */,
         title: '' /* String */,
         storage: '' /* FILE */,
-        storage_sub_image: [] /* FILE */,
+        storage_sub_images: [] /* FILE */,
+        storage_sub_images_id: [] /* UUID[] */,
         web_address: '' /* URL */
       }),
       formDirty: false,
       /* preview表示用 */
       preview: {
-        eyecatch_image_url: '',
-        storage_sub_image: []
+        eyecatch_image: null,
+        storage_sub_images: []
       }
     }
   },
@@ -251,7 +247,7 @@ export default {
     },
 
     newNumber() {
-      const subImage = this.form.storage_sub_image
+      const subImage = this.form.storage_sub_images
       for (let i = 0; i < subImage.length; i++) {
         if (subImage[i] === undefined) {
           return i
@@ -273,8 +269,15 @@ export default {
         this.form[key] = this.data[key]
       }
     })
+
+    this.form.storage_sub_images_id = []
+    for (let i = 0; i < this.data.storage_sub_images.length; i++) {
+      this.form.storage_sub_images_id[i] = this.data.storage_sub_images[i].id
+    }
+
     this.preview.eyecatch_image_url = this.data.eyecatch_image.url
     this.form.eyecatch_image = null /* ApiのObjectが入ってしまうので、空にする */
+    this.form.storage_sub_images = []
   },
 
   methods: {
@@ -318,22 +321,22 @@ export default {
       }
     },
 
-    eyecatchImageFileChange(e) {
-      // e は FILE Objectであることに注意
-      try {
-        this.preview.eyecatch_image_url = URL.createObjectURL(e)
-      } catch (err) {
-        this.preview.eyecatch_image_url = null
-      }
-    },
+    // eyecatchImageFileChange(e) {
+    //   // e は FILE Objectであることに注意
+    //   try {
+    //     this.preview.eyecatch_image_url = URL.createObjectURL(e)
+    //   } catch (err) {
+    //     this.preview.eyecatch_image_url = null
+    //   }
+    // },
 
     subImageFileChange(e) {
       // e は FILE Objectであることに注意
       const idx = this.newNumber - 1
       try {
-        this.preview.storage_sub_image[idx] = URL.createObjectURL(e)
+        this.preview.storage_sub_images[idx] = URL.createObjectURL(e)
       } catch (err) {
-        this.preview.storage_sub_image[idx] = null
+        this.preview.storage_sub_images[idx] = null
       }
     },
 

--- a/pages/users/storages/edit.vue
+++ b/pages/users/storages/edit.vue
@@ -78,14 +78,14 @@
               </v-col>
 
               <v-col cols="5">
-                <h3>Stl obj fbxファイル</h3>
+                <h3>Stl objファイル</h3>
 
                 <div class="pos-relative v-file-input-icon-none">
                   <!-- storage -->
                   <v-file-input
                     v-model="form.storage"
                     :label="$t('storage')"
-                    accept=".obj, .stl, .fbx"
+                    accept=".obj, .stl"
                     filled
                     height="200px"
                   />

--- a/pages/users/storages/edit.vue
+++ b/pages/users/storages/edit.vue
@@ -111,11 +111,12 @@
 
               <v-row>
                 <v-col cols="2">
-                  <v-file-input
+                  <base-file-input
                     v-model="form.storage_sub_image[newNumber]"
-                    @change="subImageFileChange(e, newNumber)"
+                    @change="subImageFileChange"
                     accept="image/*"
                     filled
+                    no-icon
                     height="150px"
                     label="サブ画像"
                   />
@@ -126,12 +127,13 @@
                   :key="`subImage-${subImageNum}`"
                   cols="2"
                 >
-                  <v-file-input
+                  <base-file-input
                     v-model="form.storage_sub_image[subImageNum - 1]"
-                    @change="subImageFileChange(e, subImage - 1)"
+                    @change="subImageFileChange"
                     accept="image/*"
                     filled
                     height="150px"
+                    no-icon
                     label="サブ画像"
                   />
                 </v-col>
@@ -185,12 +187,13 @@
 import axios from 'axios'
 import Form from 'vform'
 import { objectToFormData } from 'object-to-formdata'
-import UserTitle from '~/components/molecues/pages/UserTitle'
+import BaseFileInput from '@/components/molecues/form/BaseFileInput'
 import EyeCatchImageDisplay from '@/components/molecues/form/EyeCatchImageDisplay'
 import FormTitle from '@/components/molecues/form/FormTitle'
 import FormWebAddress from '@/components/molecues/form/FormWebAddress'
 import FormDescription from '@/components/molecues/form/FormDescription'
 import FormLongComment from '@/components/molecues/form/FormLongComment'
+import UserTitle from '~/components/molecues/pages/UserTitle'
 
 // ストレージIDの不一致時にエラーを投げる
 function throwNotEqualStorageID() {
@@ -200,6 +203,7 @@ function throwNotEqualStorageID() {
 export default {
   middleware: 'auth',
   components: {
+    BaseFileInput,
     EyeCatchImageDisplay,
     FormTitle,
     FormWebAddress,

--- a/pages/users/storages/edit.vue
+++ b/pages/users/storages/edit.vue
@@ -101,40 +101,6 @@
               </v-col>
             </v-row>
 
-            <div>
-              <h3>パース画像</h3>
-
-              <v-row>
-                <v-col cols="2">
-                  <base-file-input
-                    v-model="form.storage_sub_images[newNumber]"
-                    @change="subImageFileChange"
-                    accept="image/*"
-                    filled
-                    no-icon
-                    height="150px"
-                    label="サブ画像"
-                  />
-                </v-col>
-
-                <v-col
-                  v-for="subImageNum in 5"
-                  :key="`subImage-${subImageNum}`"
-                  cols="2"
-                >
-                  <base-file-input
-                    v-model="form.storage_sub_images[subImageNum - 1]"
-                    @change="subImageFileChange"
-                    accept="image/*"
-                    filled
-                    height="150px"
-                    no-icon
-                    label="サブ画像"
-                  />
-                </v-col>
-              </v-row>
-            </div>
-
             <v-row>
               <v-col cols="12">
                 <!-- description -->
@@ -182,7 +148,6 @@
 import axios from 'axios'
 import Form from 'vform'
 import { objectToFormData } from 'object-to-formdata'
-import BaseFileInput from '@/components/molecues/form/BaseFileInput'
 import FormTitle from '@/components/molecues/form/FormTitle'
 import FormWebAddress from '@/components/molecues/form/FormWebAddress'
 import FormDescription from '@/components/molecues/form/FormDescription'
@@ -198,7 +163,6 @@ function throwNotEqualStorageID() {
 export default {
   middleware: 'auth',
   components: {
-    BaseFileInput,
     FormTitle,
     FormWebAddress,
     FormDescription,
@@ -220,15 +184,12 @@ export default {
         eyecatch_image_id: '' /* UUID Never Change!! */,
         title: '' /* String */,
         storage: '' /* FILE */,
-        storage_sub_images: [] /* FILE */,
-        storage_sub_images_id: [] /* UUID[] */,
         web_address: '' /* URL */
       }),
       formDirty: false,
       /* preview表示用 */
       preview: {
-        eyecatch_image: null,
-        storage_sub_images: []
+        eyecatch_image: null
       }
     }
   },
@@ -244,16 +205,6 @@ export default {
       }
 
       return ''
-    },
-
-    newNumber() {
-      const subImage = this.form.storage_sub_images
-      for (let i = 0; i < subImage.length; i++) {
-        if (subImage[i] === undefined) {
-          return i
-        }
-      }
-      return subImage.length
     }
   },
 
@@ -270,14 +221,8 @@ export default {
       }
     })
 
-    this.form.storage_sub_images_id = []
-    for (let i = 0; i < this.data.storage_sub_images.length; i++) {
-      this.form.storage_sub_images_id[i] = this.data.storage_sub_images[i].id
-    }
-
     this.preview.eyecatch_image_url = this.data.eyecatch_image.url
     this.form.eyecatch_image = null /* ApiのObjectが入ってしまうので、空にする */
-    this.form.storage_sub_images = []
   },
 
   methods: {
@@ -319,38 +264,6 @@ export default {
       } catch (e) {
         // TODO: 何が起きるかはわからないが、そのログをとりたい。
       }
-    },
-
-    // eyecatchImageFileChange(e) {
-    //   // e は FILE Objectであることに注意
-    //   try {
-    //     this.preview.eyecatch_image_url = URL.createObjectURL(e)
-    //   } catch (err) {
-    //     this.preview.eyecatch_image_url = null
-    //   }
-    // },
-
-    subImageFileChange(e) {
-      // e は FILE Objectであることに注意
-      const idx = this.newNumber - 1
-      try {
-        this.preview.storage_sub_images[idx] = URL.createObjectURL(e)
-      } catch (err) {
-        this.preview.storage_sub_images[idx] = null
-      }
-    },
-
-    onFileChange(e) {
-      const files = e.target.files || e.dataTransfer.files
-      this.createImage(files[0])
-    },
-    // アップロードした画像を表示
-    createImage(file) {
-      const reader = new FileReader()
-      reader.onload = (e) => {
-        this.uploadedImage = e.target.result
-      }
-      reader.readAsDataURL(file)
     }
   }
 }

--- a/tests/utils/array.spec.js
+++ b/tests/utils/array.spec.js
@@ -1,6 +1,34 @@
 import * as arrayFunc from '@/utils/array'
 
 describe('utils/array', () => {
+  describe('convertToArray', () => {
+    it('配列型がそのままか(正常系)', () => {
+      expect(arrayFunc.convertToArray(['aaa', 'bbb'])).toEqual(['aaa', 'bbb']) // 一般的な配列
+      expect(arrayFunc.convertToArray(['aaa', 'bbb', ['ccc', 'ddd']])).toEqual([
+        'aaa',
+        'bbb',
+        ['ccc', 'ddd']
+      ]) // 一般的な連想配列配列
+      expect(arrayFunc.convertToArray([])).toEqual([]) // 空の配列
+    })
+
+    it('配列以外の型が配列になるか(正常系)', () => {
+      expect(arrayFunc.convertToArray(null)).toEqual([]) // 一般的な数字
+      expect(arrayFunc.convertToArray(0)).toEqual([0]) // 一般的な数字
+      expect(arrayFunc.convertToArray(1)).toEqual([1]) // 一般的な数字
+      expect(arrayFunc.convertToArray(true)).toEqual([true]) // bool型
+      expect(arrayFunc.convertToArray('aiueo')).toEqual(['aiueo']) // 一般的な文字列
+      expect(arrayFunc.convertToArray({})).toEqual([{}]) // 空のオブジェクト
+      expect(
+        arrayFunc.convertToArray({
+          a: 'aa',
+          b: ['hoge', 'foo']
+        })
+      ).toEqual([{ a: 'aa', b: ['hoge', 'foo'] }]) // 一般的なオブジェクト
+      expect(arrayFunc.convertToArray('')).toEqual(['']) // 空の文字列
+    })
+  })
+
   describe('isArray', () => {
     it('配列がtrueか(正常系)', () => {
       expect(arrayFunc.isArray(['aaa', 'bbb'])).toBeTruthy() // 一般的な配列

--- a/utils/array.js
+++ b/utils/array.js
@@ -2,7 +2,7 @@
  * 配列型に変える
  *
  * @param {*} v
- * @returns Array
+ * @returns { Array }
  */
 export const convertToArray = (v) => (v != null ? (isArray(v) ? v : [v]) : [])
 
@@ -10,5 +10,6 @@ export const convertToArray = (v) => (v != null ? (isArray(v) ? v : [v]) : [])
  * 配列型かどうか
  *
  * @param {*} v
+ * @returns { Boolean }
  */
 export const isArray = (v) => Array.isArray(v)

--- a/utils/array.js
+++ b/utils/array.js
@@ -1,1 +1,14 @@
-export const isArray = (value) => Array.isArray(value)
+/**
+ * 配列型に変える
+ *
+ * @param {*} v
+ * @returns Array
+ */
+export const convertToArray = (v) => (v != null ? (isArray(v) ? v : [v]) : [])
+
+/**
+ * 配列型かどうか
+ *
+ * @param {*} v
+ */
+export const isArray = (v) => Array.isArray(v)


### PR DESCRIPTION
# やったこと
- パース画像の廃止(#89 )
   - APIが書き終わらないため。
- LocaleDropdownを分子と有機体に分離
- ImageFileInputを追加(これを使うと画像のpreviewを表示するファイルのFormができる。
- fbxをacceptの対象外にした